### PR TITLE
Add `onDestroy` for proper cleanup + Update types

### DIFF
--- a/components/svelte/src/Particles.svelte
+++ b/components/svelte/src/Particles.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true} />
 
 <script lang="ts">
-    import { afterUpdate, createEventDispatcher } from "svelte";
+    import { afterUpdate, createEventDispatcher, onDestroy } from "svelte";
     import type { ISourceOptions } from "tsparticles-engine";
     import { tsParticles } from "tsparticles-engine";
 
@@ -21,13 +21,8 @@
 
     let oldId = id;
 
-    afterUpdate(async () => {
-        tsParticles.init();
-
-        if (particlesInit) {
-            await particlesInit(tsParticles);
-        }
-
+    function destroyOldContainer()
+    {
         if (oldId) {
             const oldContainer = tsParticles.dom().find(c => c.id === oldId);
 
@@ -35,6 +30,16 @@
                 oldContainer.destroy();
             }
         }
+    }
+
+    afterUpdate(async () => {
+        tsParticles.init();
+
+        if (particlesInit) {
+            await particlesInit(tsParticles);
+        }
+
+        destroyOldContainer();
 
         if (id) {
             const cb = container => {
@@ -64,6 +69,8 @@
             });
         }
     });
+	
+    onDestroy(destroyOldContainer);
 </script>
 
 <div {id} class={cssClass} {style} />

--- a/components/svelte/src/index.d.ts
+++ b/components/svelte/src/index.d.ts
@@ -10,6 +10,7 @@ declare module "svelte-particles" {
         url?: string;
         id?: string;
         class?: string;
+        style?: string;
         particlesInit: (engine: Engine) => Promise<void>;
     };
     type ParticlesEvents = CustomEventWrapper<{


### PR DESCRIPTION
Title should be self-explanatory.
Also, Svelte 4 [deprecated `SvelteComponentTyped`](https://github.com/sveltejs/svelte/pull/8512), so we should keep this in mind when upgrading to Svelte 5 in the future.