### PR TITLE
Fix particles beeing loaded before component ist mounted on navigation in SvelteKit

### DIFF
--- a/components/svelte/src/lib/Particles.svelte
+++ b/components/svelte/src/lib/Particles.svelte
@@ -9,6 +9,7 @@
 	let cssClass = '';
 	export { cssClass as class };
 	let canStart = false;
+	let mounted = false;
 
 	let style = '';
 	export { style };
@@ -45,13 +46,14 @@
 	});
 
 	onMount(() => {
+		mounted = true;
 		void loadParticles();
 	});
 
 	async function loadParticles(): Promise<void> {
 		destroyOldContainer();
 
-		if (!canStart) {
+		if (!canStart || !mounted) {
 			return;
 		}
 


### PR DESCRIPTION
When navigating back to a page that includes the Particles component in SvelteKit (at least in Svelte 5), the load function of the engine is sometimes ran before the Particles component is fully mounted.

When this happens, the DOM element ist not present yet and as a fallback, the engine will create a new element directly below the body.
This will cause a duplicate particles div to exist.

By checking if the component is mounted before loading the particles, this should be prevented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the loading process of particle animations to enhance performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->